### PR TITLE
Remove `warehouse_ros_mongo` dependency

### DIFF
--- a/rby1_moveit_config/package.xml
+++ b/rby1_moveit_config/package.xml
@@ -37,7 +37,6 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 


### PR DESCRIPTION
The `warehouse_ros_mongo` package does not exist in ROS 2 Humble and later, and has in fact been removed in other official MoveIt config packages.

This makes `rosdep install` fail when trying to run it (which is normally how dependencies should be installed instead of [these steps](https://github.com/RainbowRobotics/rby1-ros2?tab=readme-ov-file#install-ros-2-package-dependencies) -- I am trying to fix this now).

See for example: https://github.com/moveit/moveit_resources/blob/9e3c48401260a3d225903b901ecb596ce609219f/panda_moveit_config/package.xml#L41-L43