### PR TITLE
Add `/` to `rby1_hardware/CMakeLists.txt`

### DIFF
--- a/rby1_hardware/CMakeLists.txt
+++ b/rby1_hardware/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(/
 )
 
 link_directories(
-  ${RBY1_SDK_PATH}build/src)
+  ${RBY1_SDK_PATH}/build/src)
 
 add_library(${PROJECT_NAME} SHARED
   src/rby1_hardware_interface.cpp


### PR DESCRIPTION
I was getting a linking error when building `rby1_hardware` if I set:

```
export RBY1_SDK_PATH=~/sdk/rby1-sdk
```
(without a `/` at the end)

Because the CMakeLists.txt was missing a `/` character between the environment variable and `build/src`.

```
link_directories(
  ${RBY1_SDK_PATH}build/src)
```

I could either fix the environment variable to be `export RBY1_SDK_PATH=~/sdk/rby1-sdk/` (with a slash at the end), but this also makes things work in either case.